### PR TITLE
Update packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.15.3
+      - image: circleci/node:10.16.0
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/package.json
+++ b/package.json
@@ -5,20 +5,20 @@
   "author": "Roanoke Valley .NET User Group Officers",
   "homepage": "https://RVNUG.github.io/project-oolong",
   "dependencies": {
-    "gatsby": "^2.0.0",
-    "gatsby-plugin-lodash": "^3.0.1",
-    "gatsby-plugin-manifest": "^2.0.2",
-    "gatsby-plugin-offline": "^2.0.5",
-    "gatsby-plugin-react-helmet": "^3.0.0",
-    "gatsby-plugin-sass": "^2.0.1",
-    "gh-pages": "^2.0.1",
+    "gatsby": "^2.13.54",
+    "gatsby-plugin-lodash": "^3.1.2",
+    "gatsby-plugin-manifest": "^2.2.5",
+    "gatsby-plugin-offline": "^2.2.5",
+    "gatsby-plugin-react-helmet": "^3.1.3",
+    "gatsby-plugin-sass": "^2.1.4",
+    "gh-pages": "^2.1.1",
     "lodash": "^4.17.13",
-    "node-sass": "^4.9.3",
-    "react": "^16.5.1",
-    "react-dom": "^16.5.1",
-    "react-helmet": "^5.2.0",
+    "node-sass": "^4.12.0",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
+    "react-helmet": "^5.2.1",
     "react-scroll-to-element": "^0.2.0",
-    "react-scrollspy": "^3.3.5",
+    "react-scrollspy": "^3.4.0",
     "react-waypoint": "^8.0.3"
   },
   "keywords": [
@@ -34,7 +34,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "prettier": "^1.14.2"
+    "prettier": "^1.18.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,21 +5,21 @@
   "author": "Roanoke Valley .NET User Group Officers",
   "homepage": "https://RVNUG.github.io/project-oolong",
   "dependencies": {
-    "gatsby": "2.0.0",
-    "gatsby-plugin-lodash": "3.0.1",
-    "gatsby-plugin-manifest": "2.0.2",
-    "gatsby-plugin-offline": "2.0.5",
-    "gatsby-plugin-react-helmet": "3.0.0",
-    "gatsby-plugin-sass": "2.0.1",
-    "gh-pages": "2.0.1",
-    "lodash": "4.17.11",
-    "node-sass": "4.9.3",
-    "react": "16.5.1",
-    "react-dom": "16.5.1",
-    "react-helmet": "5.2.0",
-    "react-scroll-to-element": "0.2.0",
-    "react-scrollspy": "3.3.5",
-    "react-waypoint": "8.0.3"
+    "gatsby": "^2.0.0",
+    "gatsby-plugin-lodash": "^3.0.1",
+    "gatsby-plugin-manifest": "^2.0.2",
+    "gatsby-plugin-offline": "^2.0.5",
+    "gatsby-plugin-react-helmet": "^3.0.0",
+    "gatsby-plugin-sass": "^2.0.1",
+    "gh-pages": "^2.0.1",
+    "lodash": "^4.17.13",
+    "node-sass": "^4.9.3",
+    "react": "^16.5.1",
+    "react-dom": "^16.5.1",
+    "react-helmet": "^5.2.0",
+    "react-scroll-to-element": "^0.2.0",
+    "react-scrollspy": "^3.3.5",
+    "react-waypoint": "^8.0.3"
   },
   "keywords": [
     "gatsby"
@@ -34,7 +34,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "prettier": "1.14.2"
+    "prettier": "^1.14.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Use carat notation for package versions
- Update node to 10.16.0
- Run npm update to bring referenced packages up to latest minor release
- This took care of a security vulnerability in an older version of lodash